### PR TITLE
add subscribers count

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ First, Grab YOUR_API_KEY from your Mailerlite account (Profile > Integrations > 
 >>> api.subscribers.update(data, id='1343965485')
 ```
 
+#### Count subscribers
+
+Get the total count of all subscribers in a single call.
+
+Please, be aware that is not documented in the official API.
+
+```python
+>>> api.subscribers.count()
+```
+
 ### Groups
 
 Need documentation...

--- a/mailerlite/subscriber.py
+++ b/mailerlite/subscriber.py
@@ -190,6 +190,42 @@ class Subscribers:
         all_subscribers = [Subscriber(**res) for res in res_json]
         return all_subscribers
 
+    def count(self, stype=None, as_json=False):
+        """Get the count of subscribers of a type.
+
+        This is not documented in the API.
+        https://developers.mailerlite.com/reference#subscribers
+
+        Parameters
+        ----------
+        stype : str
+            Define subscriber type: Here are the possible values:
+            * None - All subscribers (default)
+            * active
+            * unsubscribed
+            * bounced
+            * junk
+            * unconfirmed
+        as_json : bool
+            return result as json format
+        Returns
+        -------
+        number: Integer
+            the count of subscribers
+        """
+        params = {}
+        if stype and stype.lower() in ['active', 'unsubscribed', 'bounced',
+                                       'junk', 'unconfirmed']:
+            params.update({'type': stype})
+
+        url = client.build_url('subscribers', 'count', **params)
+        res_code, res_json = client.get(url, headers=self.headers)
+
+        if as_json or not res_json:
+            return res_json
+
+        return res_json['count']
+
     def get(self, as_json=False, **identifier):
         """Get a single subscriber from your account.
 

--- a/mailerlite/subscriber.py
+++ b/mailerlite/subscriber.py
@@ -1,5 +1,6 @@
 """Manage Subcribers."""
 
+from warnings import warn
 import mailerlite.client as client
 from mailerlite.constants import Subscriber, Activity, Group, Field
 
@@ -193,7 +194,7 @@ class Subscribers:
     def count(self, stype=None, as_json=False):
         """Get the count of subscribers of a type.
 
-        This is not documented in the API.
+        Please, be aware that `count` is not documented in the official API
         https://developers.mailerlite.com/reference#subscribers
 
         Parameters
@@ -208,11 +209,14 @@ class Subscribers:
             * unconfirmed
         as_json : bool
             return result as json format
+
         Returns
         -------
         number: Integer
             the count of subscribers
         """
+        warn("Please, be aware that `count` is not documented in the official API")
+
         params = {}
         if stype and stype.lower() in ['active', 'unsubscribed', 'bounced',
                                        'junk', 'unconfirmed']:

--- a/mailerlite/subscriber.py
+++ b/mailerlite/subscriber.py
@@ -215,7 +215,7 @@ class Subscribers:
         number: Integer
             the count of subscribers
         """
-        warn("Please, be aware that `count` is not documented in the official API")
+        warn("Please, be aware that `count` is not in the official API")
 
         params = {}
         if stype and stype.lower() in ['active', 'unsubscribed', 'bounced',


### PR DESCRIPTION
The docs in MailerLite v2 API don't give a way to have the total count of subscribers (only the subscribers _within_ a group). But I figured this out, and it works: 
```
$ curl -H "X-MailerLite-ApiKey: $MAILERLITE_API_KEY" http://api.mailerlite.com/api/v2/subscribers/count
{"count":1234}
```
I don't know if it's a stable feature (I informed MailerLite they might have missed that in the docs), so I understand if you don't want to merge unofficial APIs.