### PR TITLE
Documentation linting, Group Examples and Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Please, be aware that is not documented in the official API.
 ```python
 >>> api.groups.all()
 >>> api.groups.all(limit=50)
->>> api.groups.all(ofset=10)
+>>> api.groups.all(offset=10)
 >>> api.groups.all(gfilters='My Group')
 >>> api.groups.all(group_id=12345)
 ```
@@ -182,7 +182,7 @@ Please, be aware that is not documented in the official API.
 
 ```python
 >>> api.groups.subscribers(group_id=12345)
->>> api.groups.subscribers(group_id=12345, limit=50, ofset=1)
+>>> api.groups.subscribers(group_id=12345, limit=50, offset=1)
 >>> api.groups.subscribers(group_id=12345, stype='active')
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,60 @@ Please, be aware that is not documented in the official API.
 
 ### Groups
 
-Need documentation...
+#### Get all Groups
+
+```python
+>>> api.groups.all()
+>>> api.groups.all(limit=50)
+>>> api.groups.all(ofset=10)
+>>> api.groups.all(gfilters='My Group')
+>>> api.groups.all(group_id=12345)
+```
+
+#### Rename a Group
+
+```python
+>>> api.groups.create(group_id=12345, name='My New Group')
+```
+
+#### Rename a Group
+
+```python
+>>> api.groups.update(id=12345, name='New Name')
+```
+
+#### Get a Group
+
+```python
+>>> api.groups.get(id=12345)
+```
+
+#### Delete a Group
+
+```python
+>>> api.groups.delete()
+>>> api.groups.delete(id=12345)
+```
+
+#### Get all subscribers in a Group
+
+```python
+>>> api.groups.subscribers(group_id=12345)
+>>> api.groups.subscribers(group_id=12345, limit=50, ofset=1)
+>>> api.groups.subscribers(group_id=12345, stype='active')
+```
+
+#### Get one subscriber from a Group
+
+```python
+>>> api.groups.subscriber(group_id=12345, subscriber_id=54321)
+```
+
+#### Delete one subscriber from a Group
+
+```python
+>>> api.groups.delete_subscriber(group_id=12345, subscriber_id=54321)
+```
 
 ### Segments
 

--- a/README.md
+++ b/README.md
@@ -2,26 +2,24 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9c17e95d29cd489ba86411db969a576e)](https://app.codacy.com/manual/skab12/mailerlite-api-python?utm_source=github.com&utm_medium=referral&utm_content=skoudoro/mailerlite-api-python&utm_campaign=Badge_Grade_Dashboard)
 
-![](https://travis-ci.com/skoudoro/mailerlite-api-python.svg?branch=master)
-![](https://img.shields.io/pypi/v/mailerlite-api-python.svg?target=https://pypi.python.org/pypi/mailerlite-api-python)
-
+![Build Status](https://travis-ci.com/skoudoro/mailerlite-api-python.svg?branch=master)
+![PyPi Latest Version](https://img.shields.io/pypi/v/mailerlite-api-python.svg?target=https://pypi.python.org/pypi/mailerlite-api-python)
 
 Python Wrapper for Mailerlite API v2
 
+## Getting Started
 
-# Getting Started
-
-## Installation
+### Installation
 
 This client is hosted at [PyPi](https://pypi.org/project/mailerlite-api-python/) under the name **mailerlite-api-python**, to install it, simply run
 
-```
+```terminal
 pip install mailerlite-api-python
 ```
 
 or install dev version:
 
-```
+```terminal
 git clone https://github.com/skoudoro/mailerlite-api-python.git
 pip install -e .
 ````
@@ -38,7 +36,6 @@ First, Grab YOUR_API_KEY from your Mailerlite account (Profile > Integrations > 
 
 ```python
 >>> from mailerlite import MailerLiteApi
-
 >>> api = MailerLiteApi('YOUR_API_KEY')
 ```
 
@@ -156,7 +153,7 @@ Please, be aware that is not documented in the official API.
 >>> api.groups.all(group_id=12345)
 ```
 
-#### Rename a Group
+#### Create a Group
 
 ```python
 >>> api.groups.create(group_id=12345, name='My New Group')
@@ -203,13 +200,13 @@ Please, be aware that is not documented in the official API.
 
 ### Segments
 
-##### Get list of Segments.
+#### Get list of Segments
 
 ```python
 >>> api.segments.all()
 ```
 
-##### Get count of Segments.
+#### Get count of Segments
 
 ```python
 >>> api.segments.count()
@@ -217,19 +214,19 @@ Please, be aware that is not documented in the official API.
 
 ### Fields
 
-##### Get list of Fields.
+#### Get list of Fields
 
 ```python
 >>> api.fields.all()
 ```
 
-##### Get one Field
+#### Get one Field
 
 ```python
 >>> api.fields.get(field_id=123456)
 ```
 
-##### Create / update / delete one Field
+#### Create / update / delete one Field
 
 ```python
 >>> api.fields.create(title="my custom title")
@@ -239,26 +236,26 @@ Please, be aware that is not documented in the official API.
 
 ### Webhooks
 
-##### Get list of Webhooks.
+#### Get list of Webhooks
 
 ```python
 >>> api.webhooks.all()
 ```
 
-##### Get one webhook
+#### Get one webhook
 
 ```python
 >>> api.webhooks.get(webhook_id=123456)
 ```
 
-##### Create/update/delete one webhook
+#### Create/update/delete one webhook
 
 ```python
 >>> api.webhooks.create(url="https://yoursite/script-is-here",
-... 	                event="subscriber.create")
+...                     event="subscriber.create")
 >>> api.webhooks.update(webhook_id=123456,
 ...                     url="https://yoursite/script-is-here",
-...	                event="subscriber.create")
+...                     event="subscriber.create")
 >>> api.webhooks.delete(webhook_id=123456)
 ```
 
@@ -288,21 +285,21 @@ Please, be aware that is not documented in the official API.
 >>> api.batch(batch_requests)
 ```
 
-# Tests
+## Tests
 
 - Step 1: Install pytest:
 
-```
-  $ pip install pytest
+```terminal
+  pip install pytest
 ```
 
 - Step 2: Run the tests:
 
-```
-  $ pytest -svv mailerlite
+```terminal
+  pytest -svv mailerlite
 ```
 
-# Contribute
+## Contribute
 
 We love contributions!
 
@@ -312,7 +309,6 @@ You've worked out a way to fix it – even better! Submit a [Pull Request](https
 
 Start with the [contributing guide](https://github.com/skoudoro/mailerlite-api-python/blob/master/CONTRIBUTING.rst)!
 
-# License
+## License
 
 Project under 3-clause BSD license, more informations [here](https://github.com/skoudoro/mailerlite-api-python/blob/master/LICENSE)
-

--- a/mailerlite/client.py
+++ b/mailerlite/client.py
@@ -1,6 +1,5 @@
 """Utility function for calling the API."""
 
-from os.path import join as pjoin
 import requests
 from urllib.parse import urlencode, urljoin
 from mailerlite.constants import MAILERLITE_API_V2_URL, VALID_REQUEST_METHODS

--- a/mailerlite/client.py
+++ b/mailerlite/client.py
@@ -2,7 +2,7 @@
 
 from os.path import join as pjoin
 import requests
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 from mailerlite.constants import MAILERLITE_API_V2_URL, VALID_REQUEST_METHODS
 
 
@@ -90,7 +90,7 @@ def make_request(url, method, headers=None, data=None,
         raise ValueError("Incorrect request method. method should be "
                          "{}".format(VALID_REQUEST_METHODS))
 
-    url = pjoin(MAILERLITE_API_V2_URL, url)
+    url = urljoin(MAILERLITE_API_V2_URL, url)
     hooks = hooks or requests.hooks.default_hooks()
     headers = headers or requests.utils.default_headers()
     try:

--- a/mailerlite/constants.py
+++ b/mailerlite/constants.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 
-MAILERLITE_API_V2_URL = 'https://api.mailerlite.com/api/v2'
+MAILERLITE_API_V2_URL = 'https://api.mailerlite.com/api/v2/'
 
 API_KEY_TEST = "fc7b8c5b32067bcd47cafb5f475d2fe9"
 

--- a/mailerlite/tests/test_group.py
+++ b/mailerlite/tests/test_group.py
@@ -2,18 +2,21 @@
 from mailerlite.group import Groups
 from mailerlite.constants import API_KEY_TEST, Group
 import pytest
+import responses
 
-
-def test_groups_instance():
+@pytest.fixture
+def groups():
     headers = {
         'content-type': "application/json",
         'x-mailerlite-apikey': API_KEY_TEST
     }
 
+    return Groups(headers)
+
+def test_groups_instance(groups):
     with pytest.raises(ValueError):
         Groups(API_KEY_TEST)
 
-    groups = Groups(headers)
     res_json = groups.all(as_json=True)
 
     # TEST to check if there is new key in the API
@@ -35,14 +38,7 @@ def test_groups_instance():
         assert isinstance(g, Group)
 
 
-def test_groups_crud():
-    headers = {
-        'content-type': "application/json",
-        'x-mailerlite-apikey': API_KEY_TEST
-    }
-
-    groups = Groups(headers)
-
+def test_groups_crud(groups):
     expected_group_name = "TEST_K_GROUP"
     expected_group_name_2 = "TEST_GROUP_KKK"
     e_res = groups.create(expected_group_name)
@@ -60,6 +56,83 @@ def test_groups_crud():
     with pytest.raises(OSError):
         groups.get(e_res.id)
 
+@responses.activate
+def test_get_group_using_valid_id_returns_a_group(groups):
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, 'https://api.mailerlite.com/api/v2/groups/1234',
+                 body="""{
+                    "id": 3640549,
+                    "name": "My Group",
+                    "total": 1,
+                    "active": 1,
+                    "unsubscribed": 0,
+                    "bounced": 0,
+                    "unconfirmed": 0,
+                    "junk": 0,
+                    "sent": 23,
+                    "opened": 7,
+                    "clicked": 3,
+                    "date_created": "2016-04-04 11:02:33",
+                    "date_updated": "2016-04-04 11:02:33"
+                }""", status=200,
+                 content_type='application/json')
+    
+        res = groups.get(1234)
+        assert isinstance(res, Group)
+        assert res.id == 3640549
+        assert res.name == "My Group"    
+        assert res.total == 1
+        assert res.active == 1        
+        assert res.unsubscribed == 0
+        assert res.bounced == 0
+        assert res.unconfirmed == 0
+        assert res.junk == 0
+        assert res.sent == 23
+        assert res.opened == 7
+        assert res.clicked == 3
+
+@responses.activate
+def test_get_group_using_valid_id_and_json_returns_json(groups):
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, 'https://api.mailerlite.com/api/v2/groups/1234',
+                 body="""{
+    "id": 3640549,
+    "name": "My Group",
+    "total": 1,
+    "active": 1,
+    "unsubscribed": 0,
+    "bounced": 0,
+    "unconfirmed": 0,
+    "junk": 0,
+    "sent": 23,
+    "opened": 7,
+    "clicked": 3,
+    "date_created": "2016-04-04 11:02:33",
+    "date_updated": "2016-04-04 11:02:33"
+}""", 
+                 status=200,
+                 content_type='application/json')
+    
+        res = groups.get(1234, as_json=True)
+        assert isinstance(res, dict)
+        assert res['id'] == 3640549
+        assert res['name'] == "My Group"
+        
+
+@responses.activate
+def test_get_group_using_invalid_id_returns_not_found(groups):
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, 'https://api.mailerlite.com/api/v2/groups/1234',
+                 body="""{
+  "error": {
+    "code": 123,
+    "message": "Group not found"
+  }
+}""", status=404,
+                 content_type='application/json')
+    
+        with pytest.raises(IOError):
+            groups.get(1234)
 
 def test_groups_subscriber():
     pass

--- a/mailerlite/tests/test_group.py
+++ b/mailerlite/tests/test_group.py
@@ -2,21 +2,18 @@
 from mailerlite.group import Groups
 from mailerlite.constants import API_KEY_TEST, Group
 import pytest
-import responses
 
-@pytest.fixture
-def groups():
+
+def test_groups_instance():
     headers = {
         'content-type': "application/json",
         'x-mailerlite-apikey': API_KEY_TEST
     }
 
-    return Groups(headers)
-
-def test_groups_instance(groups):
     with pytest.raises(ValueError):
         Groups(API_KEY_TEST)
 
+    groups = Groups(headers)
     res_json = groups.all(as_json=True)
 
     # TEST to check if there is new key in the API
@@ -38,7 +35,14 @@ def test_groups_instance(groups):
         assert isinstance(g, Group)
 
 
-def test_groups_crud(groups):
+def test_groups_crud():
+    headers = {
+        'content-type': "application/json",
+        'x-mailerlite-apikey': API_KEY_TEST
+    }
+
+    groups = Groups(headers)
+
     expected_group_name = "TEST_K_GROUP"
     expected_group_name_2 = "TEST_GROUP_KKK"
     e_res = groups.create(expected_group_name)
@@ -56,83 +60,6 @@ def test_groups_crud(groups):
     with pytest.raises(OSError):
         groups.get(e_res.id)
 
-@responses.activate
-def test_get_group_using_valid_id_returns_a_group(groups):
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://api.mailerlite.com/api/v2/groups/1234',
-                 body="""{
-                    "id": 3640549,
-                    "name": "My Group",
-                    "total": 1,
-                    "active": 1,
-                    "unsubscribed": 0,
-                    "bounced": 0,
-                    "unconfirmed": 0,
-                    "junk": 0,
-                    "sent": 23,
-                    "opened": 7,
-                    "clicked": 3,
-                    "date_created": "2016-04-04 11:02:33",
-                    "date_updated": "2016-04-04 11:02:33"
-                }""", status=200,
-                 content_type='application/json')
-    
-        res = groups.get(1234)
-        assert isinstance(res, Group)
-        assert res.id == 3640549
-        assert res.name == "My Group"    
-        assert res.total == 1
-        assert res.active == 1        
-        assert res.unsubscribed == 0
-        assert res.bounced == 0
-        assert res.unconfirmed == 0
-        assert res.junk == 0
-        assert res.sent == 23
-        assert res.opened == 7
-        assert res.clicked == 3
-
-@responses.activate
-def test_get_group_using_valid_id_and_json_returns_json(groups):
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://api.mailerlite.com/api/v2/groups/1234',
-                 body="""{
-    "id": 3640549,
-    "name": "My Group",
-    "total": 1,
-    "active": 1,
-    "unsubscribed": 0,
-    "bounced": 0,
-    "unconfirmed": 0,
-    "junk": 0,
-    "sent": 23,
-    "opened": 7,
-    "clicked": 3,
-    "date_created": "2016-04-04 11:02:33",
-    "date_updated": "2016-04-04 11:02:33"
-}""", 
-                 status=200,
-                 content_type='application/json')
-    
-        res = groups.get(1234, as_json=True)
-        assert isinstance(res, dict)
-        assert res['id'] == 3640549
-        assert res['name'] == "My Group"
-        
-
-@responses.activate
-def test_get_group_using_invalid_id_returns_not_found(groups):
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://api.mailerlite.com/api/v2/groups/1234',
-                 body="""{
-  "error": {
-    "code": 123,
-    "message": "Group not found"
-  }
-}""", status=404,
-                 content_type='application/json')
-    
-        with pytest.raises(IOError):
-            groups.get(1234)
 
 def test_groups_subscriber():
     pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ matplotlib
 numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
+responses


### PR DESCRIPTION
Sorry for mixing this all in one PR! All minor changes though.

- Documentation linting
The readme.md was pulling your code rating down so I ran it through a linter when I did the examples for Group.
- Group Examples
Adding some basic example for how to use the Group functionality
- Windows support
The URL building wasn't working for me on Windows - it was using the wrong sort of slashes. Adding the trailing slash (which is what the browser does anyway) fixed it but it also seemed to make sense to use the urljoin rather than the OS pjoin function.
