### PR TITLE
Add single subscriber to group

### DIFF
--- a/mailerlite/group.py
+++ b/mailerlite/group.py
@@ -181,13 +181,14 @@ class Groups:
             group object
 
         """
-        url = client.build_url('groups', group_id, 'subscribers', 'import')
+        url_params = ['groups', group_id, 'subscribers']
 
         body = {'resubscribe': resubscribe, 'autoresponders': autoresponders}
         if isinstance(subscribers_data, dict):
             body['subscribers'] = [subscribers_data, ]
         elif isinstance(subscribers_data, list):
             body['subscribers'] = subscribers_data
+            url_params.append('import')
         else:
             raise ValueError('subscribers_data should be a dict or a list of'
                              ' dict that contains the following keys: email,'
@@ -198,6 +199,8 @@ class Groups:
         if errors:
             raise ValueError('All subscribers_data should contain the'
                              ' following keys: email, name')
+
+        url = client.build_url(url_params)
         _, res_json = client.post(url, body=body, headers=self.headers)
 
         if as_json or not res_json:


### PR DESCRIPTION
On the Mailer Lite docs are two endpoints to add subscribers to specified group

https://developers.mailerlite.com/reference#add-single-subscriber

https://developers.mailerlite.com/reference#add-many-subscribers

The first one also updates the subscriber data if it exists. The second doesn't.
So I propose to if the passed subscriber data is a dict we should use the first one, otherwise, if it's a list we should use the second.
