### PR TITLE
feature: add single subscriber to specified group

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,23 @@ Please, be aware that is not documented in the official API.
 >>> api.groups.subscriber(group_id=12345, subscriber_id=54321)
 ```
 
+#### Add list of subscribers to a Group
+
+This method calls the import endpoint https://developers.mailerlite.com/reference#add-many-subscribers
+```python
+>>> api.groups.add_subscribers(group_id=12345, subscribers_data=[{"email": "john@wick.com", "name": "John Wick"}], autoresponders=False, resubscribe=False, as_json=False)
+```
+```subscriber_data``` argument accepts a list of dictionaries or just one dictionary containing the subscriber name and email 
+
+#### Add a single subscriber to a Group
+
+This method calls the add single subscriber endpoint https://developers.mailerlite.com/reference#add-single-subscriber
+```python
+>>> api.groups.add_single_subscriber(group_id=12345, subscriber_data={"email": "john@wick.com", "name": "John Wick" ...}, autoresponders=False, resubscribe=False, as_json=False)
+```
+Unlike the method above, this add only one subscriber to a group. The ```subscriber_data``` argument accepts all subscriber attributes.
+Check available attributes on https://developers.mailerlite.com/reference#create-a-subscriber
+
 #### Delete one subscriber from a Group
 
 ```python

--- a/mailerlite/group.py
+++ b/mailerlite/group.py
@@ -205,6 +205,46 @@ class Groups:
 
         return [Subscriber(**subs) for subs in res_json['imported']]
 
+    def add_single_subscriber(self, group_id, subscribers_data: dict, resubscribe=False,
+                              autoresponders=False, as_json=False):
+        """Add single new subscriber to specified group.
+
+        https://developers.mailerlite.com/v2/reference#add-single-subscriber
+
+        Parameters
+        ----------
+        group_id : int
+            group id
+        subscribers_data : dict,
+            subscribers data
+        resubscribe : bool
+            reactivate subscriber if value is true (default False)
+        autoresponders : bool
+            autoresponders will be sent if value is true (default False)
+        as_json : bool
+            return result as json format
+
+        Returns
+        -------
+        subscriber: :class:Subscriber
+            subscriber object
+
+        """
+        url = client.build_url('groups', group_id, 'subscribers')
+
+        body = {'resubscribe': resubscribe, 'autoresponders': autoresponders, **subscribers_data}
+
+        if not {'email', 'name'}.issubset(subscribers_data.keys()):
+            raise ValueError('Subscribers_data should contain the'
+                             ' following keys: email, name')
+
+        _, res_json = client.post(url, body=body, headers=self.headers)
+
+        if as_json or not res_json:
+            return res_json
+
+        return Subscriber(**res_json)
+
     def subscribers(self, group_id, limit=100, offset=0, stype=None,
                     as_json=False):
         """Get all subscribers in a specified group.

--- a/mailerlite/group.py
+++ b/mailerlite/group.py
@@ -205,8 +205,9 @@ class Groups:
 
         return [Subscriber(**subs) for subs in res_json['imported']]
 
-    def add_single_subscriber(self, group_id, subscribers_data: dict, resubscribe=False,
-                              autoresponders=False, as_json=False):
+    def add_single_subscriber(self, group_id, subscribers_data: dict,
+                              resubscribe=False, autoresponders=False,
+                              as_json=False):
         """Add single new subscriber to specified group.
 
         https://developers.mailerlite.com/v2/reference#add-single-subscriber
@@ -232,7 +233,8 @@ class Groups:
         """
         url = client.build_url('groups', group_id, 'subscribers')
 
-        body = {'resubscribe': resubscribe, 'autoresponders': autoresponders, **subscribers_data}
+        body = {'resubscribe': resubscribe, 'autoresponders': autoresponders,
+                **subscribers_data}
 
         if not {'email', 'name'}.issubset(subscribers_data.keys()):
             raise ValueError('Subscribers_data should contain the'

--- a/mailerlite/tests/test_group.py
+++ b/mailerlite/tests/test_group.py
@@ -134,4 +134,3 @@ def test_groups_single_subscriber(header):
         assert new_sub.email == mail
 
         groups.delete_subscriber(group_1.id, new_sub.id)
-

--- a/mailerlite/tests/test_group.py
+++ b/mailerlite/tests/test_group.py
@@ -106,3 +106,32 @@ def test_groups_subscriber(header):
         assert new_subs[0].email == mail
 
         groups.delete_subscriber(group_1.id, new_subs[0].id)
+
+
+def test_groups_single_subscriber(header):
+    groups = Groups(header)
+
+    n_groups = groups.all()
+    assert len(n_groups) > 0
+    group_1 = n_groups[0]
+
+    while True:
+        try:
+            num = random.randint(1000, 100000)
+            mail = generate_random_email(length=15, seed=num)
+            data = {'name': 'John',
+                    'email': mail,
+                    'fields': {'company': 'MailerLite'}
+                    }
+            new_sub = groups.add_single_subscriber(group_1.id, data)
+        except OSError:
+            time.sleep(3)
+        else:
+            break
+
+    print(new_sub)
+    if new_sub:
+        assert new_sub.email == mail
+
+        groups.delete_subscriber(group_1.id, new_sub.id)
+

--- a/mailerlite/tests/test_group.py
+++ b/mailerlite/tests/test_group.py
@@ -115,6 +115,14 @@ def test_groups_single_subscriber(header):
     assert len(n_groups) > 0
     group_1 = n_groups[0]
 
+    subs_in_group_1 = groups.subscribers(group_1.id)
+    assert len(subs_in_group_1) > 0
+
+    sub1 = subs_in_group_1[0]
+    tmp_sub = groups.subscriber(group_1.id, sub1.id)
+
+    assert sub1.email == tmp_sub.email
+
     while True:
         try:
             num = random.randint(1000, 100000)


### PR DESCRIPTION
The https://developers.mailerlite.com/reference#add-single-subscriber endpoint also create/update the subscriber data including attributes like type.

The https://developers.mailerlite.com/reference#add-many-subscribers doesn't. 