### PR TITLE
Remove python 3.6 matrix

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci-pip.yml
+++ b/.github/workflows/ci-pip.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ Then, you do not need to precise it in your code:
 
 ```python
 >>> data = {"subject": "Regular campaign subject",
-                       "groups": [2984475, 3237221],
-                       "type": "regular"}
+            "name": "Regular campaign name",
+            "groups": [2984475, 3237221],
+            "type": "regular"}
 >>> api.campaign.create(data)
 >>> api.campaign.delete(campaign_id=3971635)
 ```


### PR DESCRIPTION
Python 3.6 end-of-life is in 6 months. So, let's remove this matrix from GitHub-action