### PR TITLE
Add head and body in html

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Then, you do not need to precise it in your code:
 
 ```python
 >>> one_campaign = all_campaigns[0]
->>> html = '<h1>Title</h1><p>Content</p><p><small><a href=\"{$unsubscribe}\">Unsubscribe</a></small></p>'
+>>> html = '<head></head><body><h1>Title</h1><p>Content</p><p><small><a href=\"{$unsubscribe}\">Unsubscribe</a></small></p></body>'
 >>> plain = "Your email client does not support HTML emails. "
 >>> plain += "Open newsletter here: {$url}. If you do not want"
 >>> plain += " to receive emails from us, click here: {$unsubscribe}"

--- a/mailerlite/campaign.py
+++ b/mailerlite/campaign.py
@@ -115,12 +115,13 @@ class Campaigns:
         -------
         success : bool
 
-        Examples:
-        ---------
+        Examples
+        --------
         >>> from mailerlite import MailerLiteApi
         >>> api = MailerLiteApi('my_keys')
-        >>> html = '<h1>Title</h1><p>Content</p><p><small>'
+        >>> html = '<head></head><body><h1>Title</h1><p>Content</p><p><small>'
         >>> html += '<a href=\"{$unsubscribe}\">Unsubscribe</a></small></p>'
+        >>> html += '</body>'
         >>> plain = "Your email client does not support HTML emails. "
         >>> plain += "Open newsletter here: {$url}. If you do not want"
         >>> plain += " to receive emails from us, click here: {$unsubscribe}"
@@ -129,12 +130,14 @@ class Campaigns:
 
         Notes
         -----
+        * HTML template must contain body and head tag.
         * HTML template must contain a link for unsubscribe. It may look like
             this: <a href="{$unsubscribe}">Unsubscribe</a>
         * Some email clients do not support HTML emails so you need to set
             plain text email and it must contain these variables:
             * {$unsubscribe} - unsubscribe link
             * {$url} - URL to your HTML newsletter
+
         """
         url = client.build_url('campaigns', campaign_id, 'content')
         # Todo, Check html syntax

--- a/mailerlite/tests/test_campaign.py
+++ b/mailerlite/tests/test_campaign.py
@@ -98,8 +98,8 @@ def test_crud_campaign(header, campaign_data, campaign_data_ab):
     assert code == 200
     assert isinstance(res, dict)
 
-    html = '<h1>Title</h1><p>Content</p><p><small>'
-    html += '<a href=\"{$unsubscribe}\">Unsubscribe</a></small></p>'
+    html = '<head></head><body><h1>Title</h1><p>Content</p><p><small>'
+    html += '<a href=\"{$unsubscribe}\">Unsubscribe</a></small></p></body>'
     plain = "Your email client does not support HTML emails. "
     plain += "Open newsletter here: {$url}. If you do not want"
     plain += " to receive emails from us, click here: {$unsubscribe}"


### PR DESCRIPTION
It is now mandatory to have the tag `head` and `body` in an HTML campaign. The test should pass now.